### PR TITLE
fix: Resolve absolute import conflict for utils module (Closes #5)

### DIFF
--- a/chemprice/chemprice.py
+++ b/chemprice/chemprice.py
@@ -2,7 +2,7 @@ import requests
 import os
 import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-import utils
+from . import utils
 
 
 class PriceCollector:


### PR DESCRIPTION
This PR addresses issue #5.

It changes the absolute import `import utils` in `chemprice/chemprice.py` to a relative import `from . import utils`. This prevents potential `AttributeError` exceptions if a user's project also contains a `utils.py` file in the root directory, ensuring that `chemprice` always uses its own internal `utils` module.

Closes #5