### PR TITLE
Replaced MolPort client with v1 list-searches REST API, updated Mcule client batch call, switch Chemspace to v4 API, fixed pandas bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,16 +115,17 @@ for quantities are categorized into three families: mols, grams, and liters.
 all_prices = pc.collect(smiles_list)
 ```
 
-Molport's search is a quote, not a raw catalog dump, so it needs to know how much of each
-compound you want and where it would ship to. `collect()` exposes this as optional
-keyword arguments, defaulting to a 1 g, US-shipped, exact-match, lowest-price quote:
+Molport's and ChemSpace's searches are quotes, not raw catalog dumps, so they need to know
+where the order would ship to; Molport additionally needs to know how much of each compound
+you want. `collect()` exposes this as optional keyword arguments, defaulting to a 1 g,
+US-shipped, exact-match, lowest-price quote:
 
 ```python
 all_prices = pc.collect(
     smiles_list,
+    shipping_country="US",
     molport_amount=1,
     molport_measure="g",
-    molport_shipping_country="US",
     molport_shipping_method="consolidated",
     molport_match_types=["exact"],
     molport_selection_method="lowest price",

--- a/README.md
+++ b/README.md
@@ -63,13 +63,6 @@ Connection to Molport via API key (the following credentials are examples from M
 pc.setMolportApiKey("880d8343-8ui2-418c-9g7a-68b4e2e78c8b")
 ```
 
-In the case of Molport, it's also possible to log in with a login and password.
-
-```python
-pc.setMolportUsername("john.spade")
-pc.setMolportPassword("fasdga34a3")
-```
-
 To check the status of each key, run the following method :
 
 ```python
@@ -79,18 +72,15 @@ pc.status()
 Possible Outputs
 
 ```python
-# Username/Password and API Key are Set:
-Status: Molport: both credentials are set.
-
-# Only Username/Password or API Key is Set:
+# API Key is Set:
 Status: Molport: credential is set.
 
 # No Credential is Set:
 Status: Molport: no credential is set.
 ```
 
-Similar to the Molport connection, for ChemSpace and MCule, the approach is the same. However, ChemSpace and MCule require only an API key. You need to use
-the :mod:`setChemSpaceApiKey()` and :mod:`setMCuleApiKey()` functions, such as :
+Molport, ChemSpace, and MCule all authenticate via API key only. For ChemSpace and MCule, the approach is the same. You need to use
+the `setChemSpaceApiKey()` and `setMCuleApiKey()` functions, such as :
 
 ```python
 pc.setChemSpaceApiKey(<chemspace_api_key>)
@@ -116,7 +106,7 @@ Check: Molport API key is incorrect.
 ```
 
 If the credentials checked are correct, then it's possible
-to run the method :mod:`collect()` to obtain the price information
+to run the method `collect()` to obtain the price information
 found for the molecules. The prices are given in USD according to
 the units and quantity entered by the vendor. The units of measurement
 for quantities are categorized into three families: mols, grams, and liters.
@@ -125,15 +115,31 @@ for quantities are categorized into three families: mols, grams, and liters.
 all_prices = pc.collect(smiles_list)
 ```
 
+Molport's search is a quote, not a raw catalog dump, so it needs to know how much of each
+compound you want and where it would ship to. `collect()` exposes this as optional
+keyword arguments, defaulting to a 1 g, US-shipped, exact-match, lowest-price quote:
+
+```python
+all_prices = pc.collect(
+    smiles_list,
+    molport_amount=1,
+    molport_measure="g",
+    molport_shipping_country="US",
+    molport_shipping_method="consolidated",
+    molport_match_types=["exact"],
+    molport_selection_method="lowest price",
+)
+```
+
 The output will be a dataframe containing all price information about the molecule.
 
 | Input Smiles          | Source  | Supplier Name         | Purity | Amount | Measure | Price_USD |
 | --------------------- | ------- | --------------------- | ------ | ------ | ------- | --------- |
-| CC(=O)NC1=CC=C(C=C1)O | Molport | "ChemDiv, Inc."       | >90    | 100    | mg      | 407.1     |
+| CC(=O)NC1=CC=C(C=C1)O | Molport | "ChemDiv, Inc."       | 90     | 100    | mg      | 407.1     |
 | CC(=O)NC1=CC=C(C=C1)O | Molport | MedChemExpress Europe | 98.83  | 10     | g       | 112.8     |
 | CC(=O)NC1=CC=C(C=C1)O | Molport | TargetMol Chemicals   | 100.0  | 500    | mg      | 50.0      |
 
-With the :mod:`selectBest()` function,  we can select the best prices for each molecule. In fact, for each 
+With the `selectBest()` function,  we can select the best prices for each molecule. In fact, for each 
 unit of measurement (mol, gram, and liter) the results are calculated separately to find the best quantity/price ratio.
 
 ```python
@@ -144,9 +150,9 @@ The output will be a dataframe containing only the best quantity/price ratio of 
 
 | Input Smiles          | Source  | Supplier Name       | Purity | Amount | Measure  | Price_USD | USD/g  | USD/mol            |
 | --------------------- | ------- | ------------------- | ------ | ------ | -------- | --------- | ------ | ------------------ |
-| CC(=O)NC1=CC=C(C=C1)O | Molport | Cayman Europe       | >=98   | 500    | g        | 407.1     | 0.22   |                    |
-| O=C(C)Oc1ccccc1C(=O)O | Molport | Cayman Europe       | >=90   | 500    | g        | 112.8     | 0.1606 |                    |
-| O=C(C)Oc1ccccc1C(=O)O | Molport | Life Chemicals Inc. | >90    | 20     | micromol | 50.0      |        | 3950000.0000000005 |
+| CC(=O)NC1=CC=C(C=C1)O | Molport | Cayman Europe       | 98     | 500    | g        | 407.1     | 0.22   |                    |
+| O=C(C)Oc1ccccc1C(=O)O | Molport | Cayman Europe       | 90     | 500    | g        | 112.8     | 0.1606 |                    |
+| O=C(C)Oc1ccccc1C(=O)O | Molport | Life Chemicals Inc. | 90     | 20     | micromol | 50.0      |        | 3950000.0000000005 |
 
 ### Contact
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="600" src="https://i.imgur.com/UHf6OV0.png">
+  <img width="600" src="logo/logo_chemprice_blue.png">
 </p>
 <br />
 

--- a/chemprice/chemprice.py
+++ b/chemprice/chemprice.py
@@ -171,17 +171,18 @@ class PriceCollector:
 #------------------------------------------------------
 
 
-    def collect(self, smiles_list, progress_output=None, molport_amount=1, molport_measure="g",
-                molport_shipping_country="US", molport_shipping_method="consolidated",
+    def collect(self, smiles_list, progress_output=None, shipping_country="US", molport_amount=1,
+                molport_measure="g", molport_shipping_method="consolidated",
                 molport_match_types=None, molport_selection_method="lowest price"):
         """
         Collects data using API credentials.
 
         :param smiles_list: List of SMILES representations.
         :param progress_output: Progress output (optional).
+        :param shipping_country: Destination country code, shared by Molport's and ChemSpace's
+            quotes since both need one (default "US").
         :param molport_amount: Desired quantity per compound for Molport's quote (default 1).
         :param molport_measure: Unit for molport_amount, "mg" or "g" (default "g").
-        :param molport_shipping_country: Destination country code for Molport's quote (default "US").
         :param molport_shipping_method: "consolidated" or "direct" (default "consolidated").
         :param molport_match_types: List of Molport match types, e.g. ["exact"] (default).
         :param molport_selection_method: How Molport selects among matching offers
@@ -194,7 +195,7 @@ class PriceCollector:
         MCule = self.mcule_api_key_valid
         # Call collect_vendors function with the determined API statuses
         df = utils.collect_vendors(self, smiles_list, progress_output, Chemspace, Molport, MCule,
-                                    molport_amount, molport_measure, molport_shipping_country,
+                                    shipping_country, molport_amount, molport_measure,
                                     molport_shipping_method, molport_match_types, molport_selection_method)
 
         return df

--- a/chemprice/chemprice.py
+++ b/chemprice/chemprice.py
@@ -14,15 +14,12 @@ class PriceCollector:
     
     def __init__(self):
         self.login = {
-            'molport_username': None,
-            'molport_password': None,
             'molport_api_key': None,
             'chemspace_api_key': None,
             'mcule_api_key': None,
         }
         self.add_to_the_dictionnary(self)
 
-        self.molport_id_valid = False
         self.molport_api_key_valid = False
         self.chemspace_api_key_valid = False
         self.mcule_api_key_valid = False
@@ -32,30 +29,6 @@ class PriceCollector:
 
     def add_to_the_dictionnary(self, instance):
         PriceCollector.instances.append(instance)
-
-
-#------------------------------------------------------
-
-
-    def setMolportUsername(self, username):
-        """
-        Sets the Molport username.
-
-        :param username: The Molport username to set.
-        """
-        self.login['molport_username'] = username
-
-
-#------------------------------------------------------
-
-
-    def setMolportPassword(self, password):
-        """
-        Sets the Molport password.
-
-        :param password: The Molport password to set.
-        """
-        self.login['molport_password'] = password
 
 
 #------------------------------------------------------
@@ -101,9 +74,7 @@ class PriceCollector:
         Displays the set status of various API keys.
         """
         # Display the set status of various API keys
-        if (self.login['molport_username'] and self.login['molport_password']) and self.login['molport_api_key']:
-            print("Status: Molport : both creditentials are set.")
-        elif (self.login['molport_username'] and self.login['molport_password']) or self.login['molport_api_key']:
+        if self.login['molport_api_key']:
             print("Status: Molport : creditential is set.")
         else:
             print("Status: Molport : no credential is set.")
@@ -137,43 +108,16 @@ class PriceCollector:
         integrator_correct = 0
         
         if Molport:
-            if self.login['molport_username'] and self.login['molport_password']:
-                payload = {
-                    "User Name": self.login['molport_username'],
-                    "Authentication Code": self.login['molport_password'],
-                    "Structure": smiles,
-                    "Search Type": 5,  # Perfect research
-                    "Maximum Search Time": 60000,
-                    "Maximum Result Count": 1000,
-                    "Chemical Similarity Index": 0.9
-                }
-                # Send the request to the Molport server
-                r = requests.post('https://api.molport.com/api/chemical-search/search', json=payload)
-                # Get the Python dictionary from the server response
-                response = r.json()
-                if response["Result"]["Status"] == 1:
-                    self.molport_id_valid = True
-                    print("Check: Molport username and password are correct.")
-                    integrator_correct = 1
-                else:
-                    print("Check: Molport username and/or password are incorrect.")
-                    value_return = 0
-
-
             if self.login['molport_api_key']:
+                # Lightweight credential check via availability-searches (no pricing needed here)
+                headers = {"X-API-Key": self.login['molport_api_key']}
                 payload = {
-                    "API Key": self.login['molport_api_key'],
-                    "Structure": smiles,
-                    "Search Type": 5,  # Perfect research
-                    "Maximum Search Time": 60000,
-                    "Maximum Result Count": 1000,
-                    "Chemical Similarity Index": 0.9
+                    "search_items_type": "smiles",
+                    "search_items": [smiles],
+                    "match_types": ["exact"],
                 }
-                # Send the request to the Molport server
-                r = requests.post('https://api.molport.com/api/chemical-search/search', json=payload)
-                # Get the Python dictionary from the server response
-                response = r.json()
-                if response["Result"]["Status"] == 1:
+                r = requests.post('https://api.molport.com/v1/availability-searches', json=payload, headers=headers)
+                if r.status_code in (200, 201):
                     self.molport_api_key_valid = True
                     print("Check: Molport api key is correct.")
                     integrator_correct = 1
@@ -227,21 +171,32 @@ class PriceCollector:
 #------------------------------------------------------
 
 
-    def collect(self, smiles_list, progress_output=None):
+    def collect(self, smiles_list, progress_output=None, molport_amount=1, molport_measure="g",
+                molport_shipping_country="US", molport_shipping_method="consolidated",
+                molport_match_types=None, molport_selection_method="lowest price"):
         """
         Collects data using API credentials.
 
         :param smiles_list: List of SMILES representations.
         :param progress_output: Progress output (optional).
+        :param molport_amount: Desired quantity per compound for Molport's quote (default 1).
+        :param molport_measure: Unit for molport_amount, "mg" or "g" (default "g").
+        :param molport_shipping_country: Destination country code for Molport's quote (default "US").
+        :param molport_shipping_method: "consolidated" or "direct" (default "consolidated").
+        :param molport_match_types: List of Molport match types, e.g. ["exact"] (default).
+        :param molport_selection_method: How Molport selects among matching offers
+            ("lowest price", "minimum count of shipments", or "best offer"; default "lowest price").
         :return: A DataFrame containing collected data.
         """
         # Determine if Chemspace and/or Molport APIs are valid
         Chemspace = self.chemspace_api_key_valid
-        Molport = self.molport_api_key_valid or self.molport_id_valid
+        Molport = self.molport_api_key_valid
         MCule = self.mcule_api_key_valid
         # Call collect_vendors function with the determined API statuses
-        df = utils.collect_vendors(self, smiles_list, progress_output, Chemspace, Molport, MCule)
-        
+        df = utils.collect_vendors(self, smiles_list, progress_output, Chemspace, Molport, MCule,
+                                    molport_amount, molport_measure, molport_shipping_country,
+                                    molport_shipping_method, molport_match_types, molport_selection_method)
+
         return df
 
 

--- a/chemprice/tests/requirements.txt
+++ b/chemprice/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest==7.4.0
 requests==2.28.1
-pandas==1.3.5
+pandas>=2.0
 tqdm==4.65.0
 setuptools==69.0.3
 regex==2023.12.25

--- a/chemprice/tests/test/collect_test.py
+++ b/chemprice/tests/test/collect_test.py
@@ -9,10 +9,12 @@ from chemprice import utils
 from chemprice import chemprice as cp
 
 MOLPORT_API_KEY = os.environ.get('MOLPORT_API_KEY')
+MCULE_API_KEY = os.environ.get('MCULE_API_KEY')
 
 # Création d'instances
 instance = cp.PriceCollector()
 instance.login['molport_api_key'] = MOLPORT_API_KEY
+instance.login['mcule_api_key'] = MCULE_API_KEY
 
 
 
@@ -89,6 +91,68 @@ class TestMolportCollectPrices(unittest.TestCase):
         # Check the result
         self.assertFalse(result.empty)
         self.assertTrue(set(result['Input SMILES'].unique()).issubset(set(smiles_list)))
+
+
+
+
+class TestMculeCollectPrices(unittest.TestCase):
+
+
+
+
+    def test_empty_ids(self):
+        """
+        Test with no molecule IDs
+        """
+        # Input data
+        molecule_ids = pd.DataFrame({'ID': [], 'Input SMILES': []})
+
+        # Function application
+        result = utils.mcule_collect_prices(instance, molecule_ids)
+
+        # Check the result
+        self.assertTrue(result.empty)
+
+
+
+
+    @unittest.skipUnless(MCULE_API_KEY, "MCULE_API_KEY is not set")
+    def test_single_smiles(self):
+        """
+        Test with a single SMILES
+        """
+        # Input data
+        smiles_list = ["O=C(C)Oc1ccccc1C(=O)O"] # aspirin
+
+        # Function application
+        molecule_ids = utils.mcule_get_ids(instance, smiles_list)
+        result = utils.mcule_collect_prices(instance, molecule_ids)
+
+        # Check the result
+        self.assertFalse(result.empty)
+        self.assertListEqual(list(result.columns),
+            ["Source", "ID", "Supplier Name", "SMILES", "Purity", "Price_USD", "Amount", "Measure"])
+        self.assertTrue((result['Source'] == 'MCule').all())
+        self.assertTrue((result['ID'] == molecule_ids['ID'].iloc[0]).all())
+
+
+
+
+    @unittest.skipUnless(MCULE_API_KEY, "MCULE_API_KEY is not set")
+    def test_multiple_smiles(self):
+        """
+        Test with multiple SMILES
+        """
+        # Input data
+        smiles_list = ["CC(=O)NC1=CC=C(C=C1)O", "O=C(C)Oc1ccccc1C(=O)O"]
+
+        # Function application
+        molecule_ids = utils.mcule_get_ids(instance, smiles_list)
+        result = utils.mcule_collect_prices(instance, molecule_ids)
+
+        # Check the result
+        self.assertFalse(result.empty)
+        self.assertTrue(set(result['ID'].unique()).issubset(set(molecule_ids['ID'].unique())))
 
 
 

--- a/chemprice/tests/test/collect_test.py
+++ b/chemprice/tests/test/collect_test.py
@@ -8,228 +8,124 @@ sys.path.insert(0, os.path.abspath('..'))
 from chemprice import utils
 from chemprice import chemprice as cp
 
+MOLPORT_API_KEY = os.environ.get('MOLPORT_API_KEY')
+
 # Création d'instances
 instance = cp.PriceCollector()
-instance.login['molport_api_key'] = "880d8343-8ui2-418c-9g7a-68b4e2e78c8b"
+instance.login['molport_api_key'] = MOLPORT_API_KEY
 
 
 
 
 class TestMolportCollectPrices(unittest.TestCase):
-    
-    
-    
+
+
+
+
     def test_empty_smiles_list(self):
         """
         Test with no smiles
         """
         # Input data
-        molecule_ids = pd.DataFrame({'ID': [], 'Input SMILES': []})
-        
-        # function application
-        df = utils.molport_collect_prices(instance, molecule_ids)  
-
-        # Assert that the parsed data is an empty list
-        self.assertTrue(df.empty)
-        
-
-
-
-class TestMolportGetIds(unittest.TestCase):
-    
-    
-    
-    def test_empty_smiles_list(self):
-        """
-        Test with a SMILES list is empty
-        """
-        # Input data
         smiles_list = []
-        
-        # expected result
-        data = {'ID': [], 'Input SMILES': []}
-        expected_result = pd.DataFrame(data, dtype=object)
-        
+
         # Function application
-        result = utils.molport_get_ids(instance, smiles_list)
-        result = result.set_index(expected_result.index)
-        
-        # check the result
-        pd.testing.assert_frame_equal(result, expected_result)
-        
-        
-        
-    
+        result = utils.molport_collect_prices(instance, smiles_list)
+
+        # Check the result
+        self.assertTrue(result.empty)
+
+
+
+
+    @unittest.skipUnless(MOLPORT_API_KEY, "MOLPORT_API_KEY is not set")
     def test_imaginary_smiles(self):
         """
         Test with imaginary SMILES is recognized
         """
-        # input data
+        # Input data
         smiles_list = ["SMILOU"]
-        
-        # Expected result 
-        data = {'ID': [], 'Input SMILES': []}
-        expected_result = pd.DataFrame(data, dtype=object)
-        
+
         # Function application
-        result = utils.molport_get_ids(instance, smiles_list)
-        result = result.set_index(expected_result.index)
-        
+        result = utils.molport_collect_prices(instance, smiles_list)
+
         # Check the result
-        pd.testing.assert_frame_equal(result, expected_result)
-        
-        
-        
-        
+        self.assertTrue(result.empty)
+
+
+
+
+    @unittest.skipUnless(MOLPORT_API_KEY, "MOLPORT_API_KEY is not set")
     def test_single_smiles(self):
         """
         Test with a single SMILES
         """
         # Input data
         smiles_list = ["O=C(C)Oc1ccccc1C(=O)O"] # aspirin
-        
-        # Expected result
-        new_data = {'ID': [871622], 'Input SMILES': ["O=C(C)Oc1ccccc1C(=O)O"]}
-        expected_result = pd.DataFrame(new_data)
-        
-        # Function application
-        result = utils.molport_get_ids(instance, smiles_list)
-        
-        # Check the result
-        pd.testing.assert_frame_equal(result, expected_result)
 
-        
-        
-         
+        # Function application
+        result = utils.molport_collect_prices(instance, smiles_list)
+
+        # Check the result
+        self.assertFalse(result.empty)
+        self.assertListEqual(list(result.columns),
+            ["Source", "Input SMILES", "SMILES", "Supplier Name", "Purity", "Amount", "Measure", "Price_USD"])
+        self.assertTrue((result['Input SMILES'] == smiles_list[0]).all())
+
+
+
+
+    @unittest.skipUnless(MOLPORT_API_KEY, "MOLPORT_API_KEY is not set")
     def test_multiple_smiles(self):
         """
         Test with multiple SMILES
         """
         # Input data
         smiles_list = ["CC(=O)NC1=CC=C(C=C1)O", "CC(C)CC1=CC=C(C=C1)C(C)C(=O)O", "O=C(C)Oc1ccccc1C(=O)O"]
-        
-        # Expected result
-        data = {'ID': [150777, 47940800, 1791802, 871622], 'Input SMILES': ["CC(=O)NC1=CC=C(C=C1)O","CC(=O)NC1=CC=C(C=C1)O", "CC(C)CC1=CC=C(C=C1)C(C)C(=O)O", "O=C(C)Oc1ccccc1C(=O)O"]}
-        expected_result = pd.DataFrame(data)
-        
+
         # Function application
-        result = utils.molport_get_ids(instance, smiles_list)
-        
+        result = utils.molport_collect_prices(instance, smiles_list)
+
         # Check the result
-        pd.testing.assert_frame_equal(result, expected_result)
-        
-        
+        self.assertFalse(result.empty)
+        self.assertTrue(set(result['Input SMILES'].unique()).issubset(set(smiles_list)))
 
 
-class TestProcessPurity(unittest.TestCase):
-
-
-
-
-    def test_process_purity(self):
-        """
-        Test the good formating of the purity
-        """
-        # Input string
-        value = "('>90%',)"
-        
-        # Expected result
-        expected_result = ">90"
-        
-        # Function Application
-        result = utils.process_purity(value)
-        
-        # check the result
-        self.assertEqual(result, expected_result)
-
-
-
-
-    def test_process_purity_with_empty_string(self):
-        """
-        Test with no value 
-        """
-        # Input string
-        value = "('',)"
-        
-        # Expected result
-        expected_result = ""
-        
-        # Function application
-        result = utils.process_purity(value)
-        
-        # Check the result
-        self.assertEqual(result, expected_result)
-
-
-
-
-class TestMolportStandardizeColumns(unittest.TestCase):
-
-
-
-
-    def test_molport_standardize_columns_with_sample_data(self):
-        """
-        Test the format of standardize response
-        """
-        # Input data
-        data = {
-            'Purity': ["('',)", "('>90%',)", "('<50%',)"],
-            'Currency': ['USD', 'USD', 'USD'],
-            'Price': [100, 50, 75]
-        }
-        df = pd.DataFrame(data)
-        
-        # Expected DataFrame after standardization
-        expected_data = {
-            'Purity': ["", ">90", "<50"],
-            'Price_USD': ["100", "50", "75"],
-        }
-        expected_df = pd.DataFrame(expected_data)
-
-        # Call the function with the sample DataFrame
-        result_df = utils.molport_standardize_columns(df)
-        result_df = result_df.loc[:, ['Purity', 'Price_USD']]
-
-        # Compare the result with the expected DataFrame
-        pd.testing.assert_frame_equal(result_df, expected_df)
-        
-        
 
 
 class TestCollectVendors(unittest.TestCase):
-    
-    
-    
-    
+
+
+
+
     def test_empty_smiles_list(self):
         """
         Test with no smiles
         """
-        smiles_list = [] 
-        
-        data_result = utils.collect_vendors(instance, smiles_list, Molport=True, ChemSpace=False, MCule=False)  
+        smiles_list = []
+
+        data_result = utils.collect_vendors(instance, smiles_list, Molport=True, ChemSpace=False, MCule=False)
 
         # Assert that the parsed data is an empty list
         self.assertTrue(data_result.empty)
-        
-        
-        
-        
+
+
+
+
+    @unittest.skipUnless(MOLPORT_API_KEY, "MOLPORT_API_KEY is not set")
     def test_wrong_smiles_list(self):
         """
         Test with a wrong smiles
         """
-        smiles_list = ["wrong"] 
-        
-        data_result = utils.collect_vendors(instance, smiles_list, Molport=True, ChemSpace=False, MCule=False)  
+        smiles_list = ["wrong"]
+
+        data_result = utils.collect_vendors(instance, smiles_list, Molport=True, ChemSpace=False, MCule=False)
 
         # Assert that the parsed data is an empty list
         self.assertTrue(data_result.empty)
-        
 
-        
-    
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/chemprice/tests/test/collect_test.py
+++ b/chemprice/tests/test/collect_test.py
@@ -10,11 +10,13 @@ from chemprice import chemprice as cp
 
 MOLPORT_API_KEY = os.environ.get('MOLPORT_API_KEY')
 MCULE_API_KEY = os.environ.get('MCULE_API_KEY')
+CHEMSPACE_API_KEY = os.environ.get('CHEMSPACE_API_KEY')
 
 # Création d'instances
 instance = cp.PriceCollector()
 instance.login['molport_api_key'] = MOLPORT_API_KEY
 instance.login['mcule_api_key'] = MCULE_API_KEY
+instance.login['chemspace_api_key'] = CHEMSPACE_API_KEY
 
 
 
@@ -153,6 +155,78 @@ class TestMculeCollectPrices(unittest.TestCase):
         # Check the result
         self.assertFalse(result.empty)
         self.assertTrue(set(result['ID'].unique()).issubset(set(molecule_ids['ID'].unique())))
+
+
+
+
+class TestChemspaceCollectPrices(unittest.TestCase):
+
+
+
+
+    def test_empty_smiles_list(self):
+        """
+        Test with no smiles: no HTTP calls (including the token fetch) should be made
+        """
+        # Input data
+        smiles_list = []
+
+        # Function application
+        result = utils.chemspace_collect_prices(instance, smiles_list)
+
+        # Check the result
+        self.assertTrue(result.empty)
+
+
+
+
+    @unittest.skipUnless(CHEMSPACE_API_KEY, "CHEMSPACE_API_KEY is not set")
+    def test_single_smiles(self):
+        """
+        Test with a single SMILES
+        """
+        # Input data
+        smiles_list = ["O=C(C)Oc1ccccc1C(=O)O"] # aspirin
+
+        # Function application
+        result = utils.chemspace_collect_prices(instance, smiles_list)
+
+        # Check the result
+        self.assertFalse(result.empty)
+        self.assertListEqual(list(result.columns),
+            ["Source", "Input SMILES", "SMILES", "CAS", "Supplier Name", "Purity", "Amount", "Measure", "Price_USD"])
+        self.assertTrue((result['Source'] == 'ChemSpace').all())
+        self.assertTrue((result['Input SMILES'] == smiles_list[0]).all())
+
+
+
+
+    @unittest.skipUnless(CHEMSPACE_API_KEY, "CHEMSPACE_API_KEY is not set")
+    def test_all_categories_are_requested(self):
+        """
+        Regression test: the old client only requested categories=CSCS,CSMB,
+        silently dropping 3 of 5 (now 4 of 6) valid catalogue categories.
+        """
+        # Input data
+        smiles_list = ["CC(=O)NC1=CC=C(C=C1)O"] # acetaminophen
+
+        # Function application
+        original_post = utils.requests.post
+        captured_params = {}
+
+        def capture_post(*args, **kwargs):
+            captured_params.update(kwargs.get("params", {}))
+            return original_post(*args, **kwargs)
+
+        utils.requests.post = capture_post
+        try:
+            utils.chemspace_collect_prices(instance, smiles_list)
+        finally:
+            utils.requests.post = original_post
+
+        # Check the result
+        requested_categories = set(captured_params.get("categories", "").split(","))
+        self.assertSetEqual(requested_categories, {"CSMS", "CSMB", "CSCS", "CSSB", "CSSS", "CSFS"})
 
 
 

--- a/chemprice/tests/test/data_operation_test.py
+++ b/chemprice/tests/test/data_operation_test.py
@@ -39,11 +39,11 @@ class TestMergeDataframes(unittest.TestCase):
         expected_result.replace("nan", np.nan, inplace=True)
         
         # Function application
-        result = utils.merge_dataframes([df1, df2]) 
-        result.replace("nan", np.nan, inplace=True) 
-        
+        result = utils.merge_dataframes([df1, df2])
+        result.replace("nan", np.nan, inplace=True)
+
         # Check the result
-        pd.testing.assert_frame_equal(expected_result, result)
+        pd.testing.assert_frame_equal(expected_result, result, check_like=True)
         
         
 

--- a/chemprice/tests/test/library_test.py
+++ b/chemprice/tests/test/library_test.py
@@ -23,20 +23,6 @@ class TestPriceCollector(unittest.TestCase):
 
 
 
-    def test_setMolportUsername(self):
-        self.price_collector.setMolportUsername("test_username")
-        self.assertEqual(self.price_collector.login['molport_username'], "test_username")
-
-
-
-
-    def test_setMolportPassword(self):
-        self.price_collector.setMolportPassword("test_password")
-        self.assertEqual(self.price_collector.login['molport_password'], "test_password")
-
-
-
-
     def test_setMolportApiKey(self):
         self.price_collector.setMolportApiKey("880d8343-8ui2-418c-9g7a-68b4e2e78c8b")
         self.assertEqual(self.price_collector.login['molport_api_key'], "880d8343-8ui2-418c-9g7a-68b4e2e78c8b")
@@ -75,7 +61,6 @@ class TestPriceCollector(unittest.TestCase):
         result = self.price_collector.check()
 
         self.assertEqual(result, 0)
-        self.assertFalse(self.price_collector.molport_id_valid)
         self.assertFalse(self.price_collector.molport_api_key_valid)
 
 

--- a/chemprice/utils.py
+++ b/chemprice/utils.py
@@ -452,10 +452,11 @@ def add_standardized_columns(df):
 
     df['Measure'] = df['Measure'].astype(str)
 
-    # Apply the function to create new columns
-    df['USD/g'] = df.apply(lambda row: standardize_prices(row) if row['Measure'] in ['g', 'mg', 'kg', 'microg', 'ug' ] or re.match(r'\d+x\d+g', row['Measure']) else None, axis=1)
-    df['USD/mol'] = df.apply(lambda row: standardize_prices(row) if row['Measure'] in ['mol', 'micromol', 'mmol', 'kmol', 'umol'] else None, axis=1)
-    df['USD/l'] = df.apply(lambda row: standardize_prices(row) if (row['Measure'] in ['ml', 'microl', 'l', 'mL', 'kl', 'ul']) or re.match(r'\d+x\d+mL', row['Measure']) else None, axis=1)
+    # Apply the function to create new columns. pd.to_numeric coerces the result to a
+    # proper float64/NaN column.
+    df['USD/g'] = pd.to_numeric(df.apply(lambda row: standardize_prices(row) if row['Measure'] in ['g', 'mg', 'kg', 'microg', 'ug' ] or re.match(r'\d+x\d+g', row['Measure']) else None, axis=1), errors='coerce')
+    df['USD/mol'] = pd.to_numeric(df.apply(lambda row: standardize_prices(row) if row['Measure'] in ['mol', 'micromol', 'mmol', 'kmol', 'umol'] else None, axis=1), errors='coerce')
+    df['USD/l'] = pd.to_numeric(df.apply(lambda row: standardize_prices(row) if (row['Measure'] in ['ml', 'microl', 'l', 'mL', 'kl', 'ul']) or re.match(r'\d+x\d+mL', row['Measure']) else None, axis=1), errors='coerce')
 
     # Sort and Save the dataframe with the additional columns to a new CSV file
     df = df.sort_values(by=['Input SMILES', 'USD/g', 'USD/mol', 'USD/l'])
@@ -472,10 +473,10 @@ def filter_csv_by_min_price(df):
     # Remove rows where neither of the two values (USD/g and USD/mol) is present
     df = df.dropna(subset=["USD/g", "USD/mol", "USD/l"], how='all')
 
-    # Filter the rows from the initial dataframe, keeping only those corresponding to the smallest value of "Price_USD"
-    filtered_df_g = df[df.groupby("Input SMILES")["USD/g"].transform(min) == df["USD/g"]]
-    filtered_df_mol = df[df.groupby("Input SMILES")["USD/mol"].transform(min) == df["USD/mol"]]
-    filtered_df_l = df[df.groupby("Input SMILES")["USD/l"].transform(min) == df["USD/l"]]
+    # Filter the rows from the initial dataframe, keeping only those corresponding to the smallest value of "Price_USD".
+    filtered_df_g = df[df.groupby("Input SMILES")["USD/g"].transform('min') == df["USD/g"]]
+    filtered_df_mol = df[df.groupby("Input SMILES")["USD/mol"].transform('min') == df["USD/mol"]]
+    filtered_df_l = df[df.groupby("Input SMILES")["USD/l"].transform('min') == df["USD/l"]]
 
     # If multiple rows have the same price, keep the first one
     filtered_df_g = filtered_df_g.sample(frac=1).groupby("Input SMILES", as_index=False).first()

--- a/chemprice/utils.py
+++ b/chemprice/utils.py
@@ -249,144 +249,74 @@ def mcule_get_ids(instance, smiles_list):
 
 
 
-# Function to build packages for multiple amounts
-def build_packages(instance, df):
-    
-    mcule_token = instance.login['mcule_api_key']
-    
-    if df.empty:
-        return
-    # Define the API URL
-    url = "https://mcule.com/api/v1/iquote-queries/"
-
-    # Headers for authorization
-    headers = {
-        "Authorization": "Token " + mcule_token,
-        "Content-Type": "application/json",
-        "Accept": "application/json, */*",
-        "Accept-Encoding": "gzip, deflate"
-    }
-
-    package_ids = []  # List to store package IDs
-
-    amount_list = ["1", "5", "10", "100", "1000", "10000", "100000", "1000000"]
-
-    for index,amount in tqdm(enumerate(amount_list),total=len(amount_list)):
-        # Request body in JSON format
-        data = {
-            "amount": amount,
-            "customer_first_name": "John",
-            "customer_last_name": "Doe",
-            "delivery_country": "US",
-            "mcule_ids": df["ID"].tolist(),
-            "min_amount": None
-        }
-
-        # Send the POST request
-        response = requests.post(url, json=data, headers=headers)
-
-        # Check the response
-        if response.status_code == 201:  # Status code 201 for Created
-            results = response.json()
-            package_id = results["id"]
-            package_ids.append(package_id)  # Add package ID to the list
-        else:
-            print("POST request failed for amount:", amount)
-            print("Response code:", response.status_code)
-            print(response.text)
-
-    return package_ids
-
-
-######################################################################
-######################################################################
-
-
-# Function to get quotes
-def get_quotes(token, quote):
-    for quote_data in quote.get('group', {}).get('quotes', []):
-        quote_id = quote_data['id']
-        headers = {
-            'Authorization': f'Token {token}',
-            'Content-Type': 'application/json',
-        }
-        url = f'https://mcule.com/api/v1/iquotes/{quote_id}/'
-        response = requests.get(url, headers=headers)
-        yield response.json()
-
-
-# Function to collect prices and data from MCule API
-def mcule_collect_prices(instance, package_ids):
+# Collects prices for the given MCule IDs from the Compound List Details API
+def mcule_collect_prices(instance, molecule_ids_df, price_amounts=(1, 10, 100, 500, 1000)):
     """
-    Collects price data for molecules from MCule API.
+    Collects price data for molecules from MCule's Compound List Details API
+    (POST /api/v1/compounds/).
+
+    price_amounts is technically optional at the API level, but omitting it
+    means the response has no best_prices at all (just structural/property
+    data) -- since this function's job is prices, it's always sent.
+
+    Batches requests at 50 IDs each (the limit once price_amounts is requested)
+    and self-throttles to stay under the endpoint's 5 requests/minute burst limit.
+    Sustained usage is capped at 200 requests/day by MCule; this is not tracked
+    across separate runs, so very large batches spread across many collect()
+    calls in one day could still exceed it.
 
     :param instance: The PriceCollector instance containing API credentials.
-    :param package_ids: list containing molecule package IDs.
+    :param molecule_ids_df: DataFrame containing MCule IDs and SMILES (see mcule_get_ids).
+    :param price_amounts: Amounts in mg to request prices for (max 5 values, each <= 1000).
     :type instance: PriceCollector
-    :type package_ids: list
+    :type molecule_ids_df: pandas.DataFrame
     :return: DataFrame containing collected price data.
     :rtype: pandas.DataFrame
     """
-    
-    token = instance.login['mcule_api_key']
-    
-    data = []
-    
-    if package_ids is None:
-        # Create a DataFrame with collected data
-        df = pd.DataFrame(data, columns=["Source", "ID", "Supplier Name", "SMILES", "Purity", "Price_USD", "Amount", "Measure"])
-        return df
+    columns = ["Source", "ID", "Supplier Name", "SMILES", "Purity", "Price_USD", "Amount", "Measure"]
 
-    # Define headers for authorization
+    if molecule_ids_df.empty:
+        return pd.DataFrame([], columns=columns)
+
+    token = instance.login['mcule_api_key']
     headers = {
-        'Authorization': f'Token {token}',
+        'Authorization': 'Token ' + token,
         'Content-Type': 'application/json',
     }
 
-    for index, package_id in tqdm(enumerate(package_ids),total=len(package_ids)):
+    ids = molecule_ids_df["ID"].tolist()
+    data = []
+    request_times = []
 
-        # Construct the URL for the specific quote request
-        url = f'https://mcule.com/api/v1/iquote-queries/{package_id}/'
+    for i in tqdm(range(0, len(ids), 50)):
+        batch = ids[i:i + 50]
 
-        # Function to check the status of the quote request
-        def check_status():
-            response_package = requests.get(url, headers=headers).json()
-            status = response_package['state']
-            if status == 40:
-                return None
-            elif status == 30 and response_package['group']:
-                return response_package
-            elif status == 30 and not response_package['group']:
-                return None
-            else:
-                return 1
+        # Stay under the 5 requests/minute burst limit: drop timestamps
+        # older than 60s, and if 5 remain, wait for the oldest to age out.
+        now = time.time()
+        request_times = [t for t in request_times if now - t < 60]
+        if len(request_times) >= 5:
+            time.sleep(60 - (now - request_times[0]))
+        request_times.append(time.time())
 
-        response_package = check_status()
-        while response_package == 1:
-            time.sleep(0.5)
-            response_package = check_status()
+        payload = {
+            "mcule_ids": batch,
+            "price_amounts": list(price_amounts),
+        }
+        response = requests.post('https://mcule.com/api/v1/compounds/', headers=headers, json=payload)
 
-        if response_package is None:
+        if response.status_code != 200:
+            print(f'Error in the request for MCule batch starting at {i}: {response.status_code}')
             continue
 
-        for quote in get_quotes(token, response_package):
-            # Extract values from each product item in the quote
-            product_items = quote.get('items', [])
+        for compound in response.json().get("results", []):
+            mcule_id = compound.get("mcule_id")
+            smiles = compound.get("smiles")
+            for price in compound.get("best_prices", []):
+                data.append(("MCule", mcule_id, "", smiles, price.get("purity", ""),
+                             price.get("price", ""), price.get("amount", ""), price.get("unit", "")))
 
-            for item in product_items:
-                source = "MCule"
-                mcule_id = item.get('structure_origin_mcule_id')
-                product_supplier_name = item.get('product_supplier_name')
-                smiles = item.get('product_smiles')
-                purity = item.get('product_purity')
-                price = item.get('product_price')
-                amount = item.get('amount')
-                measure = "mg"
-                data.append((source, mcule_id, product_supplier_name, smiles, purity, price, amount, measure))
-
-    # Create a DataFrame with collected data
-    df = pd.DataFrame(data, columns=["Source", "ID", "Supplier Name", "SMILES", "Purity", "Price_USD", "Amount", "Measure"])
-
+    df = pd.DataFrame(data, columns=columns)
     return df
 
 # Merges two dataframes
@@ -609,15 +539,14 @@ def collect_vendors(instance, smiles_list, progress_output=None, ChemSpace=True,
         print(f"Collecting ID's for given {len(smiles_list)} SMILES from MCule...")
         df_molecule_ids = mcule_get_ids(instance, smiles_list)
         smiles_exists = df_molecule_ids['Input SMILES'].nunique()
-        package_id = build_packages(instance, df_molecule_ids)
         print(f"Total: {smiles_exists} molecules and {len(df_molecule_ids)} conformers are found in MCule.\n")
         progress += 1/(2*nb_integrator)
         if progress_output is not None:
-            progress_output.append(progress) 
+            progress_output.append(progress)
 
         # Get the prices and print count from MCule
         print(f"Collecting Prices for given {len(smiles_list)} IDs from MCule...")
-        mcule_prices = mcule_collect_prices(instance, package_id)
+        mcule_prices = mcule_collect_prices(instance, df_molecule_ids)
         mcule_prices = add_input_smiles_columns(df_molecule_ids, mcule_prices)
         smiles_with_price = mcule_prices.loc[mcule_prices['Price_USD'].notnull(), 'Input SMILES'].nunique()
         print(f"Total: {len(mcule_prices)} prices for {smiles_with_price} molecules are found in MCule.\n")

--- a/chemprice/utils.py
+++ b/chemprice/utils.py
@@ -129,38 +129,47 @@ def chemspace_get_token(instance):
 
 
 # Collects prices for the given SMILES and coverts them into dataframe
-def chemspace_collect_prices(instance, smiles_list):
+def chemspace_collect_prices(instance, smiles_list, ship_to_country="US"):
     """
-    Collects price data for molecules from ChemSpace API.
+    Collects price data for molecules from ChemSpace's v4 API (POST /v4/search/exact).
 
     :param instance: The PriceCollector instance containing API credentials.
     :param smiles_list: list containing molecule SMILES.
+    :param ship_to_country: Destination country code; required by the v4 API (default "US").
     :type instance: PriceCollector
     :type smiles_list: list
     :return: DataFrame containing collected price data.
     :rtype: pandas.DataFrame
     """
+    columns = ["Source", "Input SMILES", "SMILES", "CAS", "Supplier Name", "Purity", "Amount", "Measure", "Price_USD"]
+
+    if not smiles_list:
+        return pd.DataFrame([], columns=columns)
 
     access_token = chemspace_get_token(instance)
-    url = "https://api.chem-space.com/v3/search/exact"
+    url = "https://api.chem-space.com/v4/search/exact"
     headers = {
-        "Accept": "application/json; version=3.1",
+        "Accept": "application/json; version=4.1",
         "Authorization": "Bearer " + access_token,
     }
     params = {
         "count": 3,
         "page": 1,
-        "categories": "CSCS,CSMB"
+        "categories": "CSMS,CSMB,CSCS,CSSB,CSSS,CSFS",
+        "shipToCountry": ship_to_country,
     }
 
     response_data = []
 
     for index, smiles in tqdm(enumerate(smiles_list),total=len(smiles_list)):
+        # v4 documents multipart/form-data as the only accepted body encoding;
+        # requests' `data=` sends application/x-www-form-urlencoded instead, so
+        # `files=` is used here to force the correct encoding.
         data = {
-            "SMILES": smiles
+            "SMILES": (None, smiles)
         }
 
-        response = requests.post(url, headers=headers, data=data, params=params)
+        response = requests.post(url, headers=headers, files=data, params=params)
 
         # Check if the request was successful (status code 200)
         if response.status_code == 200:
@@ -177,9 +186,13 @@ def chemspace_collect_prices(instance, smiles_list):
             print("Request failed with status code:", response.status_code)
             print("Response content:", response.text)
 
-        # Pause for 1.5 seconds between each request
-        if index < len(smiles_list) - 1:
-            time.sleep(1.5)
+        # ChemSpace reports the real remaining quota on every response; only wait
+        # once it's actually exhausted, rather than guessing a fixed delay.
+        remaining = response.headers.get("X-Rate-Limit-Remaining")
+        reset_seconds = response.headers.get("X-Rate-Limit-Reset")
+        if remaining is not None and reset_seconds is not None and int(remaining) <= 0 \
+                and index < len(smiles_list) - 1:
+            time.sleep(int(reset_seconds))
 
     chemspace_data = []
     
@@ -201,7 +214,7 @@ def chemspace_collect_prices(instance, smiles_list):
 
                     chemspace_data.append((source, input_smiles, smiles, cas, supplier_name, purity, amount, measure, price_usd))
                     
-    df = pd.DataFrame(chemspace_data, columns=["Source", "Input SMILES", "SMILES", "CAS", "Supplier Name", "Purity", "Amount", "Measure", "Price_USD"])
+    df = pd.DataFrame(chemspace_data, columns=columns)
     df = df.dropna(subset=["Price_USD"], how='all')
 
     return df
@@ -495,7 +508,7 @@ def filter_csv_by_min_price(df):
 
 
 def collect_vendors(instance, smiles_list, progress_output=None, ChemSpace=True, Molport=True, MCule=True,
-                     molport_amount=1, molport_measure="g", molport_shipping_country="US",
+                     shipping_country="US", molport_amount=1, molport_measure="g",
                      molport_shipping_method="consolidated", molport_match_types=None,
                      molport_selection_method="lowest price"):
 
@@ -511,7 +524,7 @@ def collect_vendors(instance, smiles_list, progress_output=None, ChemSpace=True,
         # Get the prices and print count from MolPort
         print(f"Collecting Prices for given {len(smiles_list)} SMILES from MolPort...")
         molport_prices = molport_collect_prices(instance, smiles_list, amount=molport_amount,
-                                                  measure=molport_measure, shipping_country=molport_shipping_country,
+                                                  measure=molport_measure, shipping_country=shipping_country,
                                                   shipping_method=molport_shipping_method,
                                                   match_types=molport_match_types,
                                                   selection_method=molport_selection_method)
@@ -525,7 +538,7 @@ def collect_vendors(instance, smiles_list, progress_output=None, ChemSpace=True,
     if ChemSpace:
         # Get the prices and print count from ChemSpace
         print(f"Collecting Prices for given {len(smiles_list)} SMILES from ChemSpace...")
-        chemspace_prices=chemspace_collect_prices(instance, smiles_list)
+        chemspace_prices=chemspace_collect_prices(instance, smiles_list, ship_to_country=shipping_country)
         unique_smiles_count = chemspace_prices['Input SMILES'].nunique()
         smiles_with_price_cs = len(chemspace_prices[chemspace_prices['Price_USD'].notnull()])
         print(f"Total: {smiles_with_price_cs} prices for {unique_smiles_count} molecules are found in ChemSpace.\n")

--- a/chemprice/utils.py
+++ b/chemprice/utils.py
@@ -10,167 +10,85 @@ from tqdm import tqdm
 ######################################################################
 
 
-# Collects molport ids from the given list smiles (we will use this ids to search)
-def molport_get_ids(instance, smiles_list):
-    # List to store t he IDs and SMILES
-    id_smiles_list = []
-
-    molport_username = instance.login['molport_username']
-    molport_password = instance.login['molport_password']
-    molport_api_key = instance.login['molport_api_key']
-        
-    for smiles in tqdm(smiles_list):
-        # Data to send to the Molport server
-        if molport_username != None:
-            payload = {
-                "User Name": molport_username,
-                "Authentication Code": molport_password,
-                "Structure": smiles,
-                "Search Type": 5, # Perfect research
-                "Maximum Search Time": 60000,
-                "Maximum Result Count": 1000,
-                "Chemical Similarity Index": 0.9
-            }
-
-        else:
-            payload = {
-                "API Key": molport_api_key,
-                "Structure": smiles,
-                "Search Type": 5, # Perfect research
-                "Maximum Search Time": 60000,
-                "Maximum Result Count": 1000,
-                "Chemical Similarity Index": 0.9
-            }
-
-        # Send the request to the Molport server
-        r = requests.post('https://api.molport.com/api/chemical-search/search', json=payload)
-
-        # Get the Python dictionary from the server response
-        response = r.json()
-
-        if response["Result"]["Status"] == 1:
-            molecules = response["Data"]["Molecules"]
-
-            # Iterate over the molecules and their information
-            for molecule in molecules:
-                molecule_id = molecule["Id"]
-                id_smiles_list.append((molecule_id, smiles))
-
-    df = pd.DataFrame(id_smiles_list, columns=["ID", "Input SMILES"])
-
-    return df
-
-
-######################################################################
-######################################################################
-
-
-#cleans the purity text
-def process_purity(value):
-    if value == "('',)":
-        return ""
-    else:
-        return value.strip('\'(%\'),')
-
-# standardize the price and purity columns with chemspace data   
-def molport_standardize_columns(data):
-    
-    data = data.astype(str)
-    
-    # Apply the custom function to the 'Purity' column
-    data['Purity'] = data['Purity'].apply(process_purity)
-
-    # Create new columns Price_USD and Price_EUR with empty strings
-    data['Price_USD'] = ""
-
-    # Replace relevant values with corresponding prices
-    data.loc[data['Currency'] == 'USD', 'Price_USD'] = data.loc[data['Currency'] == 'USD', 'Price']
-
-    # Remove the Price and Currency columns
-    data.drop(['Price', 'Currency'], axis=1, inplace=True)
-    
-    return data
-
-
-######################################################################
-######################################################################
-
-
-# Collects prices for the given ids and coverts them into dataframe
-def molport_collect_prices(instance, molecule_ids):
+# Collects prices for the given SMILES from Molport's v1 list-searches API
+def molport_collect_prices(instance, smiles_list, amount=1, min_amount=None, measure="g", shipping_country="US",
+                            shipping_method="consolidated", match_types=None, selection_method="lowest price",
+                            poll_interval=2, poll_timeout=300):
     """
-    Collects price data for molecules from Molport API.
+    Collects price data for molecules from Molport's v1 REST API (POST /v1/list-searches).
+
+    Submits every SMILES in a single batched search; Molport itself selects offers
+    according to selection_method across its full supplier network, so no supplier
+    category is silently skipped the way the old "Screening Block Suppliers"-only
+    integration was.
 
     :param instance: The PriceCollector instance containing API credentials.
-    :param molecule_ids: DataFrame containing molecule IDs and SMILES.
+    :param smiles_list: list containing molecule SMILES.
+    :param min_amount: Minimum acceptable amount; defaults to ``amount`` (the API requires
+        this field even though its own OpenAPI spec documents it as optional).
     :type instance: PriceCollector
-    :type molecule_ids: pandas.DataFrame
+    :type smiles_list: list
     :return: DataFrame containing collected price data.
     :rtype: pandas.DataFrame
     """
-    all_molecules_data = []
+    columns = ["Source", "Input SMILES", "SMILES", "Supplier Name", "Purity", "Amount", "Measure", "Price_USD"]
 
-    molport_username = instance.login['molport_username']
-    molport_password = instance.login['molport_password']
-    molport_api_key = instance.login['molport_api_key']
+    if not smiles_list:
+        return pd.DataFrame([], columns=columns)
 
-    for _, row in tqdm(molecule_ids.iterrows(),total=len(molecule_ids)):
-        molecule_id = row['ID']
-        smiles = row['Input SMILES']
+    if match_types is None:
+        match_types = ["exact"]
 
-        if molport_username != None:
-            # Molport API URL using the API key and molecule ID
-            url = f'https://api.molport.com/api/molecule/load?molecule={molecule_id}&username={molport_username}&authenticationcode={molport_password}'
-        else:
-            url = f'https://api.molport.com/api/molecule/load?molecule={molecule_id}&apikey={molport_api_key}'
+    if min_amount is None:
+        min_amount = amount
 
-        # Send the POST request to the Molport API
-        response = requests.post(url)
+    headers = {"X-API-Key": instance.login['molport_api_key']}
+    payload = {
+        "search_items_type": "smiles",
+        "search_items": smiles_list,
+        "amount": amount,
+        "min_amount": min_amount,
+        "measure": measure,
+        "shipping_country": shipping_country,
+        "shipping_method": shipping_method,
+        "match_types": match_types,
+        "selection_method": selection_method,
+    }
 
-        # Check the response status
-        if response.status_code == 200:
-            # The request was successful
-            data = response.json()
-            data['Data']['Molecule']['Input SMILES'] = smiles
-            all_molecules_data.append(data)
-        else:
-            # The request failed
-            print(f'Error in the request for molecule {molecule_id}: {response.status_code}')
+    response = requests.post('https://api.molport.com/v1/list-searches', json=payload, headers=headers)
+    if response.status_code not in (200, 201):
+        print(f'Error submitting Molport search: {response.status_code}')
+        return pd.DataFrame([], columns=columns)
 
+    search_key = response.json()["search_key"]
 
-    molport_data = []
-    
-    for data_ in all_molecules_data:
-            input_smiles = data_['Data']['Molecule']['Input SMILES']
-            smiles = data_['Data']['Molecule']['SMILES']
-            supplier_data = data_["Data"]["Molecule"]["Catalogues"]["Screening Block Suppliers"]
+    status_url = f'https://api.molport.com/v1/list-searches/status/{search_key}'
+    elapsed = 0
+    while elapsed < poll_timeout:
+        status = requests.get(status_url, headers=headers).json()
+        if status.get("processing_completed_at"):
+            break
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+    else:
+        print(f'Molport search {search_key} timed out after {poll_timeout} seconds.')
+        return pd.DataFrame([], columns=columns)
 
-            # Write each data row
-            for supplier in supplier_data:
-                supplier_name = supplier["Supplier Name"]
-                catalogues = supplier["Catalogues"]
+    results_response = requests.get(f'https://api.molport.com/v1/list-searches/{search_key}', headers=headers)
+    # "results" is nested under "request" in the live response, despite the
+    # published OpenAPI spec showing it as a top-level field.
+    results = results_response.json().get("request", {}).get("results", [])
 
-                for catalogue in catalogues:
-                    purity = catalogue.get("Purity", ""),
-
-                    last_update_date = catalogue.get("Last Update Date Exact", "")
-                    packings = catalogue["Available Packings"]
-
-                    for packing in packings:
-                        
-                        source = "Molport"
-                        amount = packing.get("Amount", "")
-                        measure = packing.get("Measure", "")
-                        price = packing.get("Price", "")
-                        currency = packing.get("Currency", "")
-                        
-                    molport_data.append((source, input_smiles, smiles, last_update_date, supplier_name, purity, price, amount, measure, currency))
+    # Unmatched SMILES come back as {"search_query": ..., "status": "not found"}
+    # with no price fields at all, rather than being omitted from the array.
+    molport_data = [
+        ("Molport", item.get("search_query", ""), item.get("smiles", ""), item.get("supplier_name", ""),
+         item.get("purity", ""), item.get("qty", ""), item.get("unit", ""), item.get("net_price", ""))
+        for item in results if item.get("status") == "found"
+    ]
 
     # Create a DataFrame with collected data
-    df = pd.DataFrame(molport_data, columns=["Source", "Input SMILES", "SMILES", "Last Update Date Exact", "Supplier Name", "Purity", "Price", "Amount", "Measure", "Currency"])
-
-    # read the file again
-    df = molport_standardize_columns(df)
+    df = pd.DataFrame(molport_data, columns=columns)
 
     #remove if no price rows
     df = df.dropna(subset=["Price_USD"], how='all')
@@ -646,34 +564,32 @@ def filter_csv_by_min_price(df):
 ######################################################################
 
 
-def collect_vendors(instance, smiles_list, progress_output=None, ChemSpace=True, Molport=True, MCule=True):
-    
+def collect_vendors(instance, smiles_list, progress_output=None, ChemSpace=True, Molport=True, MCule=True,
+                     molport_amount=1, molport_measure="g", molport_shipping_country="US",
+                     molport_shipping_method="consolidated", molport_match_types=None,
+                     molport_selection_method="lowest price"):
+
     time_start  = time.perf_counter()
-    
+
     nb_integrator = sum([ChemSpace, Molport, MCule])
     progress = 0
-    
+
     # List of selected suppliers
     selected_providers = []
 
     if Molport:
-        # Get the molecule IDs and print count MolPort
-        print(f"Collecting ID's for given {len(smiles_list)} SMILES from MolPort...")
-        df_molecule_ids = molport_get_ids(instance, smiles_list)
-        smiles_exists = df_molecule_ids['Input SMILES'].nunique()
-        print(f"Total: {smiles_exists} molecules and {len(df_molecule_ids)} conformers are found in MolPort.\n")
-        progress += 3/(4*nb_integrator)
-        if progress_output is not None:
-            progress_output.append(progress) 
-
         # Get the prices and print count from MolPort
-        print(f"Collecting Prices for given {len(smiles_list)} IDs from MolPort...")
-        molport_prices=molport_collect_prices(instance, df_molecule_ids)
+        print(f"Collecting Prices for given {len(smiles_list)} SMILES from MolPort...")
+        molport_prices = molport_collect_prices(instance, smiles_list, amount=molport_amount,
+                                                  measure=molport_measure, shipping_country=molport_shipping_country,
+                                                  shipping_method=molport_shipping_method,
+                                                  match_types=molport_match_types,
+                                                  selection_method=molport_selection_method)
         smiles_with_price = molport_prices.loc[molport_prices['Price_USD'].notnull(), 'Input SMILES'].nunique()
         print(f"Total: {len(molport_prices)} prices for {smiles_with_price} molecules are found in MolPort.\n")
-        progress += 1/(4*nb_integrator)
+        progress += 1/nb_integrator
         if progress_output is not None:
-            progress_output.append(progress) 
+            progress_output.append(progress)
         selected_providers.append(("Molport", molport_prices))
 
     if ChemSpace:

--- a/chemprice/utils.py
+++ b/chemprice/utils.py
@@ -423,7 +423,7 @@ def extract_unit_bulk(unit_string):
     parts = re.search(r'(\d+)x(\d+)(\D+)', unit_string)
     if parts:
         bulk = int(parts.group(1)) * int(parts.group(2))
-        unit = parts.group(3).lower()
+        unit = parts.group(3).strip().lower()
         return bulk, unit
     else:
         bulk = re.search(r'\d+', unit_string)
@@ -463,7 +463,9 @@ def add_standardized_columns(df):
         df['USD/l'] = ''
         return df
 
-    df['Measure'] = df['Measure'].astype(str)
+    # Some APIs (e.g. Molport) return unit strings with stray whitespace
+    # (e.g. " g" instead of "g"), which breaks exact-match lookups below.
+    df['Measure'] = df['Measure'].astype(str).str.strip()
 
     # Apply the function to create new columns. pd.to_numeric coerces the result to a
     # proper float64/NaN column.

--- a/chemprice/utils.py
+++ b/chemprice/utils.py
@@ -83,7 +83,7 @@ def molport_collect_prices(instance, smiles_list, amount=1, min_amount=None, mea
     # with no price fields at all, rather than being omitted from the array.
     molport_data = [
         ("Molport", item.get("search_query", ""), item.get("smiles", ""), item.get("supplier_name", ""),
-         item.get("purity", ""), item.get("qty", ""), item.get("unit", ""), item.get("net_price", ""))
+         item.get("purity", ""), item.get("qty", ""), item.get("unit", "").strip(), item.get("net_price", ""))
         for item in results if item.get("status") == "found"
     ]
 

--- a/chemprice/utils.py
+++ b/chemprice/utils.py
@@ -10,6 +10,20 @@ from tqdm import tqdm
 ######################################################################
 
 
+# Molport's "unit" field encodes the pack size the price is quoted for, as a
+# combined "<amount> <unit>" string (e.g. "5 g", "25 g", "10 mL") -- it is not
+# a bare unit like other vendors return. "qty" is how many of that pack were
+# selected, so the amount actually priced is qty * pack size.
+def _parse_molport_pack_size(unit_string, qty):
+    match = re.search(r'([\d.]+)\s*([a-zA-Z]+)', str(unit_string))
+    if not match:
+        return "", ""
+    pack_size = float(match.group(1))
+    unit = match.group(2).lower()
+    qty = float(qty) if qty not in (None, "") else 1.0
+    return qty * pack_size, unit
+
+
 # Collects prices for the given SMILES from Molport's v1 list-searches API
 def molport_collect_prices(instance, smiles_list, amount=1, min_amount=None, measure="g", shipping_country="US",
                             shipping_method="consolidated", match_types=None, selection_method="lowest price",
@@ -81,11 +95,15 @@ def molport_collect_prices(instance, smiles_list, amount=1, min_amount=None, mea
 
     # Unmatched SMILES come back as {"search_query": ..., "status": "not found"}
     # with no price fields at all, rather than being omitted from the array.
-    molport_data = [
-        ("Molport", item.get("search_query", ""), item.get("smiles", ""), item.get("supplier_name", ""),
-         item.get("purity", ""), item.get("qty", ""), item.get("unit", "").strip(), item.get("net_price", ""))
-        for item in results if item.get("status") == "found"
-    ]
+    molport_data = []
+    for item in results:
+        if item.get("status") != "found":
+            continue
+        amount, unit = _parse_molport_pack_size(item.get("unit", ""), item.get("qty", ""))
+        molport_data.append((
+            "Molport", item.get("search_query", ""), item.get("smiles", ""), item.get("supplier_name", ""),
+            item.get("purity", ""), amount, unit, item.get("net_price", "")
+        ))
 
     # Create a DataFrame with collected data
     df = pd.DataFrame(molport_data, columns=columns)
@@ -437,6 +455,8 @@ def extract_unit_bulk(unit_string):
             unit = unit.group().lower()
         else:
             return None, None
+
+        return bulk, unit
 
 #Convert all prices into USD/g or USD/mol or USD/l
 def standardize_prices(row):

--- a/docs/source/api_reference/api.rst
+++ b/docs/source/api_reference/api.rst
@@ -10,10 +10,6 @@ chemprice.PriceCollector
 
 .. autoclass:: PriceCollector
 
-    .. automethod:: setMolportUsername
-
-    .. automethod:: setMolportPassword
-
     .. automethod:: setMolportApiKey
 
     .. automethod:: setChemSpaceApiKey

--- a/docs/source/user_manual/getting_started.rst
+++ b/docs/source/user_manual/getting_started.rst
@@ -36,21 +36,15 @@ Enter the API key for each integrator
 Now that the ``PriceCollector`` class has been created, we need to connect to one 
 or more integrators via an API key. 
 
-Connection to Molport via API key (the following credentials are examples from Molport API documentations, and users need to obtain their personal credentials from Molport platform):
+Connection to Molport via API key (the following credential is an example from Molport's API documentation, and users need to obtain their personal credential from the Molport platform):
 
 .. code:: python3
-    
+
     pc.setMolportApiKey("880d8343-8ui2-418c-9g7a-68b4e2e78c8b")
 
-In the case of Molport, it's also possible to log in with a login and password. 
-ChemSpace and Mcule support only API keys.
+Molport, ChemSpace, and Mcule all authenticate via API key only.
 
-.. code:: python3
-    
-    pc.setMolportUsername("john.spade")
-    pc.setMolportPassword("fasdga34a3")
-
-To check the status of each key, run the : 
+To check the status of each key, run the :
 
 .. code:: python3
     
@@ -97,22 +91,38 @@ Possible Outputs:
     # API Key is Set but not correct:
     Check: Molport api key is incorrect.
 
-If the credentials checked are correct, then it's possible 
-to run the method :mod:`collect()` to obtain the price information 
-found on the molecule. The prices are given in USD according to 
-the units and quantity entered by the vendor. The units of measurement 
+If the credentials checked are correct, then it's possible
+to run the method :mod:`collect()` to obtain the price information
+found on the molecule. The prices are given in USD according to
+the units and quantity entered by the vendor. The units of measurement
 for quantities are categorized into three families: moles, grams, and liters.
 
 .. code:: python3
 
     all_prices = pc.collect(smiles_list)
 
+Molport's search is a quote, not a raw catalog dump, so it needs to know how much of each
+compound you want and where it would ship to. :mod:`collect()` exposes this as optional
+keyword arguments, defaulting to a 1 g, US-shipped, exact-match, lowest-price quote:
+
+.. code:: python3
+
+    all_prices = pc.collect(
+        smiles_list,
+        molport_amount=1,
+        molport_measure="g",
+        molport_shipping_country="US",
+        molport_shipping_method="consolidated",
+        molport_match_types=["exact"],
+        molport_selection_method="lowest price",
+    )
+
 The output will be a dataframe containing all price information of the molecules in the search list.
 
 +-----------------------+---------+-----------------------+--------+--------+---------+-----------+
 | Input Smiles          | Source  | Supplier Name         | Purity | Amount | Measure | Price_USD |
 +=======================+=========+=======================+========+========+=========+===========+
-| CC(=O)NC1=CC=C(C=C1)O | Molport | "ChemDiv, Inc."       | >90    | 100    | mg      | 407.1     |
+| CC(=O)NC1=CC=C(C=C1)O | Molport | "ChemDiv, Inc."       | 90     | 100    | mg      | 407.1     |
 +-----------------------+---------+-----------------------+--------+--------+---------+-----------+
 | CC(=O)NC1=CC=C(C=C1)O | Molport | MedChemExpress Europe | 98.83  | 10     | g       | 112.8     |
 +-----------------------+---------+-----------------------+--------+--------+---------+-----------+
@@ -132,9 +142,9 @@ The output will be a dataframe containing only the best quantity/price ratio for
 +-----------------------+---------+---------------------+--------+--------+----------+-----------+--------+--------------------+
 | Input Smiles          | Source  | Supplier Name       | Purity | Amount | Measure  | Price_USD | USD/g  | USD/mol            |
 +=======================+=========+=====================+========+========+==========+===========+========+====================+
-| CC(=O)NC1=CC=C(C=C1)O | Molport | Cayman Europe       | >=98   | 500    | g        | 407.1     | 0.22   |                    |
+| CC(=O)NC1=CC=C(C=C1)O | Molport | Cayman Europe       | 98     | 500    | g        | 407.1     | 0.22   |                    |
 +-----------------------+---------+---------------------+--------+--------+----------+-----------+--------+--------------------+
-| O=C(C)Oc1ccccc1C(=O)O | Molport | Cayman Europe       | >=90   | 500    | g        | 112.8     | 0.1606 |                    |
+| O=C(C)Oc1ccccc1C(=O)O | Molport | Cayman Europe       | 90     | 500    | g        | 112.8     | 0.1606 |                    |
 +-----------------------+---------+---------------------+--------+--------+----------+-----------+--------+--------------------+
-| O=C(C)Oc1ccccc1C(=O)O | Molport | Life Chemicals Inc. | >90    | 20     | micromol | 50.0      |        | 3950000.0000000005 |
+| O=C(C)Oc1ccccc1C(=O)O | Molport | Life Chemicals Inc. | 90     | 20     | micromol | 50.0      |        | 3950000.0000000005 |
 +-----------------------+---------+---------------------+--------+--------+----------+-----------+--------+--------------------+

--- a/docs/source/user_manual/getting_started.rst
+++ b/docs/source/user_manual/getting_started.rst
@@ -101,17 +101,18 @@ for quantities are categorized into three families: moles, grams, and liters.
 
     all_prices = pc.collect(smiles_list)
 
-Molport's search is a quote, not a raw catalog dump, so it needs to know how much of each
-compound you want and where it would ship to. :mod:`collect()` exposes this as optional
-keyword arguments, defaulting to a 1 g, US-shipped, exact-match, lowest-price quote:
+Molport's and ChemSpace's searches are quotes, not raw catalog dumps, so they need to know
+where the order would ship to; Molport additionally needs to know how much of each compound
+you want. :mod:`collect()` exposes this as optional keyword arguments, defaulting to a 1 g,
+US-shipped, exact-match, lowest-price quote:
 
 .. code:: python3
 
     all_prices = pc.collect(
         smiles_list,
+        shipping_country="US",
         molport_amount=1,
         molport_measure="g",
-        molport_shipping_country="US",
         molport_shipping_method="consolidated",
         molport_match_types=["exact"],
         molport_selection_method="lowest price",

--- a/notebook/vendor-search.ipynb
+++ b/notebook/vendor-search.ipynb
@@ -1,6 +1,19 @@
 {
   "cells": [
     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> **Note (out of date):** This notebook reimplements an older, standalone version of the vendor-search pipeline. It was included in the 2024 release of the `chemprice` package (1.1.0) and does not reflect the current API clients:\n",
+        ">\n",
+        "> - **MolPort**: uses the retired v1.0 `chemical-search/search`/`molecule/load` endpoints and username/password auth, and only reads the `\"Screening Block Suppliers\"` catalogue. The current implementation in `chemprice/utils.py` uses the v1 `/v1/list-searches` REST API instead.\n",
+        "> - **MCule**: uses the old `iquote-queries` flow (rate-limited to 10 requests/day). The current implementation uses the `/compounds/` endpoint instead.\n",
+        "> - **ChemSpace**: only requests 2 of 5 valid `categories` values.\n",
+        ">\n",
+        "> For current, working usage, see the `chemprice` package (`chemprice/utils.py`, `chemprice/chemprice.py`) and `docs/source/user_manual/getting_started.rst`."
+      ]
+    },
+    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies for the librairy and the notebooks
 requests==2.28.1
-pandas==1.3.5
+pandas>=2.0
 tqdm==4.65.0
 
 # Dependencies for the documentation
@@ -10,5 +10,5 @@ sphinx-rtd-theme==1.3.0rc1
 # Dependencies for tests
 pytest==7.4.0
 requests==2.28.1
-pandas==1.3.5
+pandas>=2.0
 tqdm==4.65.0

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,9 @@ setup(
         "Topic :: Scientific/Engineering"
     ],
     keywords="chemoinformatics",
-    install_requires=[    
+    install_requires=[
         "requests==2.28.1",
-        "pandas==1.3.5",
+        "pandas>=2.0",
         "tqdm==4.65.0"
     ],
     test_suite="pytest",


### PR DESCRIPTION
Updated use of Molport Molecule API and Chemical Search API with [List Search API](https://docs.molport.com/swagger-ui/#/List%20Search%20API).
- Replaced `molport_get_ids`/`molport_collect_prices` with a single batched client for POST /v1/list-searches
- Modified to include building block suppliers in addition to screening block suppliers
- Changed to validating credentials in `check()` with [Availability Search API](https://docs.molport.com/swagger-ui/#/Availability%20Search%20API) (lightweight check)
- Removed `setMolportUsername`/`setMolportPassword` (available in old API only)
- Removed `process_purity`/`molport_standardize_columns` (dead code, old API's tuple-string purity artifact no longer exists)

Updated MCule client to avoid API limits
- Implemented batch calls
- Checked state of crash on rate-limited responses
- Added rate limiter (not automatically reported by MCule)
- Changed `price_amounts` tiers based on constraints (max is 1000 mg)

Migrated Chemspace client from v3 to v4
- Included more categories for all possible codes (CSMS,CSMB,CSCS,CSSB,CSSS,CSFS)
- Added `shipToCountry` parameter (required)
- Used rate limits reported by Chemspace to adjust next calls

Fixed bugs with pandas
- Changed `add_standardized_columns` to avoid a data type error (`TypeError: '<' not supported between NoneType and NoneType`)
- Used skip-`NaN` aggregation to get the correct order when there are `NaN`-containing groups